### PR TITLE
Rephrasing new authorship

### DIFF
--- a/_posts/2022-12-02-zep1.markdown
+++ b/_posts/2022-12-02-zep1.markdown
@@ -9,8 +9,9 @@ permalink: /zep1-update/
 ---
 
 The Zarr community is working on a new version of Zarr, V3, which was drafted
-and proposed via [ZEP0001] by [Alistair Miles]. We, [Jonathan Striebel] and
-[Jeremy Maitin-Shepard], have now taken over the authorship of [ZEP0001].
+and proposed via [ZEP0001] by [Alistair Miles]. Due to time constraints, we,
+[Jonathan Striebel] and [Jeremy Maitin-Shepard], are taking over the lead authorship
+of the v3 proposal.
 
 The specification is now being finalized and **needs your feedback** before the [Zarr
 Steering Council] and the [Zarr Implementation Council] vote on it. In two weeks,


### PR DESCRIPTION
The previous phrasing sounded too much like we sought active ownership of the ZEP, this fits better IMO. cc @jbms