### PR TITLE
Add new blog post: Welcoming Outreachy 2022 Interns

### DIFF
--- a/_posts/2022-12-12-welcoming-outreachy-interns-2022.markdown
+++ b/_posts/2022-12-12-welcoming-outreachy-interns-2022.markdown
@@ -9,7 +9,7 @@ permalink: /welcoming-outreachy-2022-interns/
 
 ## Hi Zarr Community! 🙋🏻‍♂️
 
-The holidays are just around the corner, and we have something good to share with the community (Yes, it’s better than Christmas presents 🎁). October was full of surprises for the Zarr Community as we decided to participate in the [Outreachy](https://www.outreachy.org/) program for the first time.
+The holidays are just around the corner, and we wanted to share the good news about the [Outreachy](https://www.outreachy.org/) participation, which shows the drive and motivation of contributors, the trust and strength of the open-source community, and the resiliency of the [Zarr](https://zarr.dev/) project.
 
 > The Initiation 🏁
 

--- a/_posts/2022-12-12-welcoming-outreachy-interns-2022.markdown
+++ b/_posts/2022-12-12-welcoming-outreachy-interns-2022.markdown
@@ -1,0 +1,51 @@
+---
+layout: post
+title: "Welcoming Outreachy 2022 Interns"
+description: Blog Post on Welcoming Outreachy 2022 Interns
+date: 2022-12-12
+categories: blog
+permalink: /welcoming-outreachy-2022-interns/
+---
+
+## Hi Zarr Community! 🙋🏻‍♂️
+
+The holidays are just around the corner, and we have something good to share with the community (Yes, it’s better than Christmas presents 🎁). October was full of surprises for the Zarr Community as we decided to participate in the [Outreachy](https://www.outreachy.org/) program for the first time.
+
+> The Initiation 🏁
+
+It was October’s first week, and our community [Gitter channel](https://gitter.im/zarr-developers/community) saw a sudden wave of incoming messages from Outreachy participants (i.e. Outreachies). Initially, the [messages](https://gitter.im/zarr-developers/community?at=6341d1aa64f29419bfcd1456) mainly stated that they were excited to find the Zarr project and looked forward to contributing. I was happy to see the initial response from the Outreachies. I thought I did a good job writing the project descriptions over at the Outreachy portal that everyone liked and now considering working with us for three months.
+
+> Speed-bumps 🚧
+
+But after a few days, the [messages](https://gitter.im/zarr-developers/community?at=6346721c133b6458ca223c89) shifted the tone from “Hi, I’m excited to be here…” to “Hi, I have this technical issue…” and their intensity increased manifold. It started getting difficult to manage the Zarr community and incoming Outreachies on a single Gitter channel, and we thought of creating a separate [Gitter channel](https://gitter.im/zarr-developers/outreachy-contributors-dec-2022) for the Outreachies. We started interacting with all the participants and helping them out late at night.
+
+> 🤝🏻
+
+Everyone was going fine until we noticed that there should be a central place/guide that every aspiring intern could refer to when starting their open-source contribution journey to Zarr with Outreachy. We also thought it’d help us to prevent answering the same questions multiple times at multiple places (Gitter, Emails, Twitter etc.) After this, I wrote two blogs on helping the Outreachies during their contribution phase, which can be seen here:
+
+- [Outreachy Contributor Guide 2022](https://zarr.dev/blog/outreachy-contributor-guide/)
+- [Outreachy Contributor Guide 2022 - Part 2](https://zarr.dev/blog/outreachy-contributor-guide-part-2/)
+
+> The strength of open-source 💪🏻
+
+I remember in one of the [Zarr community meetings](https://zarr.dev/community-calls/), all of us were happy to see the participation by Outreachies during the phase. During the meeting, I mentioned that [Josh](https://github.com/joshmoore) and I are the ones who are primarily engaging with the participants, and we’d love to see others from the community helping us. After that meeting, I could see some of the long-time contributors of Zarr jumping in and helping us in aiding the Outreachies by answering their questions, reviewing pull requests, providing suggestions and finally merging their PRs. I believe that’s the real spirit of Open-Source, and I was [almost idyllic](https://open.spotify.com/track/7lq08zctLOESidAM58kjq6?si=dd79ce744c834e01) to see that.
+
+After four weeks of the contribution phase, here are some stats:
+
+- 30+ closed PRs across [zarr-developers](https://github.com/zarr-developers/)
+- 15+ new issues created on GitHub to highlight hidden flaws
+- 100+ new users are now part of the Zarr Community
+- 200+ queries resolved via Gitter, Email, Twitter etc.
+
+> Finally... 🥺
+
+It took us some time to pick the best of the many qualified applicants, and after going through the immensely talented pool of Outreachies, we finally selected two interns to work with Zarr for the December 2022 cohort. They are:
+
+- [BRANDON AWA](https://github.com/DON-BRAN) from Cameroon, and they’ll be working on Creating Tutorials for Zarr 🎉
+- [Weddy Gikunda](https://github.com/caviere) from Kenya and she’ll be working on Testing the support and interoperability of Zarr Zip Stores 🎉
+
+Though it’s only been a week since they started their work, they’re on an excellent start. Weddy’s blog can be seen [here](https://caviere.github.io/weddy_blog/), where she’ll be posting her updates. Similarly, Awa’s blog can be seen [here](https://don-bran.github.io/), and I like the blog’s theme. Both of them have posted their first introductory blog post, and I was motivated to learn about their core values which drives them to work hard with integrity.
+
+I’ll be cross-posting their upcoming blog posts regularly here, so please keep an eye on this page. I’m excited to help them build new things for Zarr and look forward to working with them. Until next time. Peace! ✌🏻
+
+~Sanket Verma


### PR DESCRIPTION
Wrote a blog post summarising the Outreachy contribution phase and welcoming new interns for December 2022 cohort.

CC: @joshmoore